### PR TITLE
Issues#32 apply jwt

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render
 from rest_framework import viewsets
 from api.users import serializers
 from apps.users.models import ZaboUser
+from rest_framework.permissions import AllowAny, IsAuthenticated
 
 
 # Create your views here.
@@ -11,5 +12,6 @@ class UserViewSet(viewsets.ModelViewSet):
         `update` and `destroy` actions.
 
     """
+    permission_classes = (IsAuthenticated, )
     serializer_class = serializers.ZabouserSerializer
     queryset = ZaboUser.objects.all()

--- a/api/zaboes/views.py
+++ b/api/zaboes/views.py
@@ -9,7 +9,8 @@ from zabo.common.permissions import IsOwnerOrReadOnly
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 from rest_framework import status
 # Create your views here.
-from zabo.common.permissions import IsAuthenticated
+#from zabo.common.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from api.common.viewset import ActionAPIViewSet
 
 
@@ -27,7 +28,8 @@ class ZaboViewSet(viewsets.ModelViewSet, ActionAPIViewSet):
         'retrieve': ZaboSerializer,
     }
 
-    # permission_classes = (IsAuthenticated, )
+    #permission_classes = (AllowAny, )
+    permission_classes = (IsAuthenticated, )
 
     def list(self, request):
         queryset = self.filter_queryset(self.get_queryset())

--- a/zabo/settings/components/rest_framework.py
+++ b/zabo/settings/components/rest_framework.py
@@ -32,7 +32,6 @@ REST_FRAMEWORK = {
     'DATETIME_FORMAT': '%Y-%m-%d %H:%M'
 }
 
-"""
 JWT_AUTH = {
     'JWT_AUTH_HEADER_PREFIX': 'ZABO',
     'JWT_ALLOW_REFRESH': True,
@@ -40,4 +39,4 @@ JWT_AUTH = {
     'JWT_RESPONSE_PAYLOAD_HANDLER':
         'zabo.common.utils.jwt_response_payload_handler'
 }
-"""
+

--- a/zabo/settings/components/rest_framework.py
+++ b/zabo/settings/components/rest_framework.py
@@ -32,6 +32,7 @@ REST_FRAMEWORK = {
     'DATETIME_FORMAT': '%Y-%m-%d %H:%M'
 }
 
+"""
 JWT_AUTH = {
     'JWT_AUTH_HEADER_PREFIX': 'ZABO',
     'JWT_ALLOW_REFRESH': True,
@@ -39,3 +40,4 @@ JWT_AUTH = {
     'JWT_RESPONSE_PAYLOAD_HANDLER':
         'zabo.common.utils.jwt_response_payload_handler'
 }
+"""


### PR DESCRIPTION
Apply JSON Web Token.
Use ZABO as JWT authentication header prefix, instead of JWT.